### PR TITLE
test: witness for redaction-by-default during fragment replace

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -73,4 +73,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test:core:1.5.0'
+    androidTestImplementation 'com.google.truth:truth:1.4.5'
 }

--- a/sample/src/androidTest/java/io/cobrowse/sample/ui/RedactionByDefaultDisappearingFragmentTest.kt
+++ b/sample/src/androidTest/java/io/cobrowse/sample/ui/RedactionByDefaultDisappearingFragmentTest.kt
@@ -1,0 +1,103 @@
+package io.cobrowse.sample.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import io.cobrowse.CobrowseIO
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RedactionByDefaultDisappearingFragmentTest {
+
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+    private val prefs get() = PreferenceManager.getDefaultSharedPreferences(context)
+
+    @Before
+    fun enableRedactionByDefault() {
+        prefs.edit().putBoolean("isRedactionByDefaultEnabled", true).commit()
+    }
+
+    @After
+    fun disableRedactionByDefault() {
+        prefs.edit().remove("isRedactionByDefaultEnabled").commit()
+    }
+
+    @Test
+    fun whenAccountFragmentIsDisappearing_collectRedactedViewsInFragments_includesItsRootView() {
+        ActivityScenario.launch(TestRedactionByDefaultActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.fragmentContainer
+                val accountFragment = TestAccountFragment()
+
+                activity.supportFragmentManager.beginTransaction()
+                    .add(container.id, accountFragment, "account")
+                    .commitNow()
+
+                val accountView = accountFragment.requireView()
+
+                assertThat(accountView.parent).isEqualTo(container)
+                assertThat(container.indexOfChild(accountView)).isNotEqualTo(-1)
+                assertThat(activity.collectRedactedViewsInFragments()).contains(accountView)
+
+                container.startViewTransition(accountView)
+                container.removeView(accountView)
+
+                try {
+                    assertThat(accountView.parent).isEqualTo(container)
+                    assertThat(container.indexOfChild(accountView)).isEqualTo(-1)
+
+                    assertThat(activity.collectRedactedViewsInFragments()).contains(accountView)
+                } finally {
+                    container.endViewTransition(accountView)
+                }
+            }
+        }
+    }
+}
+
+class TestAccountFragment : Fragment(), CobrowseIO.Redacted {
+
+    lateinit var accountEmail: TextView
+    lateinit var accountName: TextView
+    lateinit var logOut: Button
+    lateinit var privacyPolicy: Button
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = LinearLayout(requireContext()).apply {
+        orientation = LinearLayout.VERTICAL
+        accountName = TextView(requireContext()).also { addView(it) }
+        accountEmail = TextView(requireContext()).also { addView(it) }
+        logOut = Button(requireContext()).apply { text = "Log out" }.also { addView(it) }
+        privacyPolicy = Button(requireContext()).apply { text = "Privacy Policy" }
+            .also { addView(it) }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        (activity as? ICobrowseRedactionContainer)?.notifyFragmentViewCreated(this)
+    }
+
+    override fun onDestroyView() {
+        (activity as? ICobrowseRedactionContainer)?.notifyFragmentViewDestroyed(this)
+        super.onDestroyView()
+    }
+
+    override fun redactedViews(): MutableList<View> =
+        mutableListOf(accountEmail, accountName)
+}

--- a/sample/src/debug/AndroidManifest.xml
+++ b/sample/src/debug/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name="io.cobrowse.sample.ui.TestRedactionByDefaultActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+    </application>
+</manifest>

--- a/sample/src/debug/java/io/cobrowse/sample/ui/TestRedactionByDefaultActivity.kt
+++ b/sample/src/debug/java/io/cobrowse/sample/ui/TestRedactionByDefaultActivity.kt
@@ -1,0 +1,27 @@
+package io.cobrowse.sample.ui
+
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AppCompatActivity
+
+@VisibleForTesting
+class TestRedactionByDefaultActivity : AppCompatActivity(),
+    ICobrowseRedactionContainer by CobrowseRedactionContainer() {
+
+    lateinit var fragmentContainer: FrameLayout
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        fragmentContainer = FrameLayout(this).apply {
+            id = View.generateViewId()
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+        }
+        setContentView(fragmentContainer)
+    }
+}


### PR DESCRIPTION
Witness for cobrowseio/cobrowse-sdk-android-examples#57.

- `upstream/master` + this test → **RED** at line 53: 
  - `expected to contain: LinearLayout (root); but was: [TextView, TextView]`
- this branch → **GREEN**: 
  - `OK (1 test)`

Please feel free to adapt, merge or close as you prefer.